### PR TITLE
The div should have a higher z-index

### DIFF
--- a/src/index.svelte
+++ b/src/index.svelte
@@ -45,6 +45,7 @@
 
 <style>
   div {
+    z-index: 9999;
     position: fixed;
     width: 100%;
     top: 0;


### PR DESCRIPTION
The div must have a higher z-index otherwise it will behave as a transparent element